### PR TITLE
Fix test failures

### DIFF
--- a/spec/governor/article_spec.rb
+++ b/spec/governor/article_spec.rb
@@ -10,17 +10,17 @@ module Governor
     # find_all_by_date(year, month = nil, day = nil, page = 1)
     context "#time_delta" do
       it "should span a whole year when that's all I ask for" do
-        time = Time.parse('1/1/2010')
+        time = Time.parse('2010-01-01')
         ArticleStub.time_delta(2010).should == [time, time.end_of_year]
       end
       
       it "should span a month when that's specified" do
-        time = Time.parse('8/1/2010')
+        time = Time.parse('2010-08-01')
         ArticleStub.time_delta(2010, 8).should == [time, time.end_of_month]
       end
       
       it "should span a single day when that's specified" do
-        time = Time.parse('8/17/2010')
+        time = Time.parse('2010-08-17')
         ArticleStub.time_delta(2010, 8, 17).should == [time, time.end_of_day]
       end
     end


### PR DESCRIPTION
  1) Governor::Article#time_delta should span a month when that's specified
     Failure/Error: ArticleStub.time_delta(2010, 8).should == [time, time.end_of_month]
       expected: [2010-01-08 00:00:00 -0600, 2010-01-31 23:59:59 -0600]
            got: [2010-08-01 00:00:00 -0500, 2010-08-31 23:59:59 -0500](using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -[2010-01-08 00:00:00 -0600, 2010-01-31 23:59:59 -0600]
       +[2010-08-01 00:00:00 -0500, 2010-08-31 23:59:59 -0500]
     # ./spec/governor/article_spec.rb:19:in `block (3 levels) in module:Governor'

  2) Governor::Article#time_delta should span a single day when that's specified
     Failure/Error: time = Time.parse('8/17/2010')
     ArgumentError:
       argument out of range
     # ./spec/governor/article_spec.rb:23:in `block (3 levels) in module:Governor'
